### PR TITLE
changing Roadmap link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -43,7 +43,7 @@ layout: layout
 	<div class="center"><div class="feature">
   <h2>Build the Roadmap</h2>
   <p>The future belongs to you! Help us build the key features of the tool by telling us what you want!</p>
-  <a href="https://github.com/shards/na/madglory/gamelocker-vainglory/issues" target="top" class="button">Build the Roadmap</a>
+  <a href="https://trello.com/b/3J3rN95m/vainglory-api-roadmap" target="top" class="button">Build the Roadmap</a>
 </div>
 </div>
 	<div class="right"><div class="feature">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -43,13 +43,13 @@ layout: layout
 	<div class="center"><div class="feature">
   <h2>Build the Roadmap</h2>
   <p>The future belongs to you! Help us build the key features of the tool by telling us what you want!</p>
-  <a href="https://trello.com/b/3J3rN95m/vainglory-api-roadmap" target="top" class="button">Build the Roadmap</a>
+  <a href="https://bit.ly/gamelocker-roadmap-repo" target="top" class="button">Build the Roadmap</a>
 </div>
 </div>
 	<div class="right"><div class="feature">
   <h2>Read the Docs</h2>
   <p>See the type of information you can use to build your own Vainglory Data-Driven Website.</p>
-  <a href="docs" class="button">See the API</a>
+  <a href="https://bit.ly/vainglory-docs" class="button">See the API</a>
 </div>
 </div>
 </section>


### PR DESCRIPTION
Fixes #17.

Changes proposed:
  - Updates the URL for the roadmap to the trello link
