### PR TITLE
game title stylization fixes in website titles

### DIFF
--- a/source/docs/index.html.md
+++ b/source/docs/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: VainGlory Game Data Service Reference
+title: Vainglory Game Data Service Reference
 
 language_tabs:
   - shell

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -9,7 +9,7 @@ layout: layout
     		<div class="top-bar-left">
     			<ul class="menu">
     				<li class="logo menu-text">
-    					<span>VainGlory Developer Portal</span>
+    					<span>Vainglory Developer Portal</span>
     				</li>
     			</ul>
     		</div>


### PR DESCRIPTION
Changes proposed:
Fixes typo in title from VainGlory to Vainglory.