### PR TITLE
moves discussion environment from Slack to Discord

### DIFF
--- a/source/docs/index.html.md
+++ b/source/docs/index.html.md
@@ -9,7 +9,7 @@ language_tabs:
 
 toc_footers:
   - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/milestones'>Build the Roadmap!</a>
-  - <a href='https://gamedevslack.herokuapp.com/'>Chat in Slack (&#35;vaingloryapi)!</a>
+  - <a href='http://discord.com/vaingloryapi'>Chat on Discord!</a>
   - <a href='https://github.com/madglory/gamelocker-vainglory'>Peep the Docs!</a>
   - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/issues'>Log a bug!</a>
 
@@ -42,7 +42,7 @@ test the interface, and provide feedback to our development team.
 While we initially took a different approach, based on community feedback
 the Server now makes every attempt to implement the required features of the
 [JSON-API](http://jsonapi.org/) specification. Where a deviation occurs, it is likely
-unintentional and can be reported to the team in our [Slack (#vaingloryapi)](gamedevelopment.slack.com).
+unintentional and can be reported to the team in the [Vainglory API community Discord](discord.me/vaingloryapi).
 
 We show example language bindings using CURL and plan to add libraries for Ruby,
 NodeJS, Java, Python and more. You can view code examples in the dark area to the right, and
@@ -71,7 +71,7 @@ You can see the current version and deploy date by viewing the [Status](https://
 ## Community API's
 
 Community contributions are welcome and rewarded with good karma (and swag!) 
-If you are currently working on an API, let us know in the Slack channel and we will add a link! 
+If you are currently working on an API, let us know on the Discord server and we will add a link! 
 
 **Java**
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -36,8 +36,8 @@ layout: layout
 <section class="features row">
 	<div class="left"><div class="feature">
   <h2>Discover Possibilities</h2>
-  <p>Visit the forum to discuss the uses of the developer portal for the community.</p>
-  <a href="https://gamedevslack.herokuapp.com" target="top" class="button">Chat in Slack</a>
+  <p>Visit the Vainglory API Community Discord to discuss the uses of the developer portal with the Vainglory community.</p>
+  <a href="http://discord.me/vaingloryapi" target="top" class="button">Chat on Discord</a>
 </div>
 </div>
 	<div class="center"><div class="feature">


### PR DESCRIPTION
After discussions with @genexp @clarkefoley and @tmcarmona16, we were feeling that moving the Vainglory API discussion to Discord would help get developers working with he API closer to the Vainglory player community where a lot of VG players are in order to share ideas and feedback on projects. This also will allow full control over the discussion environment (bot things!) without having to go through our current lovely host (Thanks Jamal!) on the game dev Slack team where we live now. We thought the sooner the better on this move while there's still a relatively small user base on the Slack channel.

Changes proposed:
  - Moving chat home base from Slack to Discord