### PR TITLE
fixes typo in Discord URLs, game title capitalization, link to 'Issues'

### DIFF
--- a/source/docs/index.html.md
+++ b/source/docs/index.html.md
@@ -11,7 +11,7 @@ toc_footers:
   - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/milestones'>Build the Roadmap!</a>
   - <a href='http://discord.me/vaingloryapi'>Chat on Discord!</a>
   - <a href='https://github.com/madglory/gamelocker-vainglory'>Peep the Docs!</a>
-  - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/issues'>Log a bug!</a>
+  - <a href='https://github.com/madglory/gamelocker-vainglory/issues'>Log a bug!</a>
 
 includes:
   - datacenters

--- a/source/docs/index.html.md
+++ b/source/docs/index.html.md
@@ -9,7 +9,7 @@ language_tabs:
 
 toc_footers:
   - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/milestones'>Build the Roadmap!</a>
-  - <a href='http://discord.com/vaingloryapi'>Chat on Discord!</a>
+  - <a href='http://discord.me/vaingloryapi'>Chat on Discord!</a>
   - <a href='https://github.com/madglory/gamelocker-vainglory'>Peep the Docs!</a>
   - <a href='https://github.com/shards/na/madglory/gamelocker-vainglory/issues'>Log a bug!</a>
 
@@ -42,7 +42,7 @@ test the interface, and provide feedback to our development team.
 While we initially took a different approach, based on community feedback
 the Server now makes every attempt to implement the required features of the
 [JSON-API](http://jsonapi.org/) specification. Where a deviation occurs, it is likely
-unintentional and can be reported to the team in the [Vainglory API community Discord](discord.me/vaingloryapi).
+unintentional and can be reported to the team in the [Vainglory API community Discord](http://discord.me/vaingloryapi).
 
 We show example language bindings using CURL and plan to add libraries for Ruby,
 NodeJS, Java, Python and more. You can view code examples in the dark area to the right, and

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -9,7 +9,7 @@ layout: layout
     		<div class="top-bar-left">
     			<ul class="menu">
     				<li class="logo menu-text">
-    					<span>VainGlory Developer Portal</span>
+    					<span>Vainglory Developer Portal</span>
     				</li>
     			</ul>
     		</div>


### PR DESCRIPTION
fixes typo in Discord URLs and game title capitalization 

Changes proposed:
  - correcting 2 URLs to Discord on Docs
  - correcting 1 website title typo on developer site
