### PR TITLE
Removing confusing Markdown code from plain text

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
 We try to categorize all issues, with easy to understand prefixes. If applicable, please prefix your issue title with one of the following:
 
-- **Question:** General how-to question, can be answered by developers or other community members.
-- **Feature:** Request for additional functionality, query parameters, etc.
-- **Bug:** Problem with API functionality not working as documented
-- **Data**: Request for additional data.
+- Question: General how-to question, can be answered by developers or other community members.
+- Feature: Request for additional functionality, query parameters, etc.
+- Bug: Problem with API functionality not working as documented
+- Data: Request for additional data.
 
 If this is a bug report, please include:
 - [ ] API Version from [Status](https://api.dc01.gamelockerapp.com/status)


### PR DESCRIPTION
This file isn't viewed anywhere where Markdown is used, but rather in a field of plain text. Including the Markdown for bold (**) was causing some confusion that lead to users were putting Bold Markdown in Issue titles.