### PR TITLE
Python API: update syntax for 0.4.0

### DIFF
--- a/source/includes/_matches.md
+++ b/source/includes/_matches.md
@@ -9,7 +9,7 @@ duration, gameMode, and more.  Each Match has two Rosters.
 ## Rosters
 
 ```python
->>> match = api.match("eca49808-d510-11e6-bf26-cec0c932ce01")
+>>> match = api.match("800aa130-f8a9-11e6-ba38-0667892d829e")
 >>> match.rosters[0].stats["gold"]
 32344
 ```
@@ -58,12 +58,12 @@ within the context of a Match and are not exposed as a standalone resource.
 
 ## Participants
 ```python
->>> match = api.match("eca49808-d510-11e6-bf26-cec0c932ce01")
+>>> match = api.match("800aa130-f8a9-11e6-ba38-0667892d829e")
 >>> participant_left_1 = match.rosters[0].participants[0]
->>> participant_left_1.stats.farm
-49.25
->>> participant_left_1.actor.pretty()
-'Skye'
+>>> participant_left_1.stats["farm"]
+52
+>>> participant_left_1.actor
+'*Ringo*'
 ```
 
 ```go
@@ -210,7 +210,7 @@ curl "https://api.dc01.gamelockerapp.com/shards/na/matches/0123b560-d74c-11e6-b8
 
 
 ```python
-api.match("0123b560-d74c-11e6-b845-0671096b3e30")
+api.match("800aa130-f8a9-11e6-ba38-0667892d829e")
 ```
 
 

--- a/source/includes/_matches.md
+++ b/source/includes/_matches.md
@@ -111,6 +111,9 @@ curl "https://api.dc01.gamelockerapp.com/shards/na/matches?page[limit]=3&page[of
 '2017-01-11T02:38:35Z'
 >>> m[0].rosters[0]
 <gamelocker.datatypes.Roster object at 0x7fe47abb0a90>
+>>> # specify the region
+>>> api.matches(region="eu")
+[...]
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_players.md
+++ b/source/includes/_players.md
@@ -17,7 +17,7 @@ curl "https://api.dc01.gamelockerapp.com/shards/na/players/6abb30de-7cb8-11e4-8b
 >>> p
 <gamelocker.datatypes.Player object at 0x7fe4814ede48>
 >>> p.stats["lifetimeGold"]
-10536.0
+14716.75
 >>> p.name
 'boombastic04'
 ```


### PR DESCRIPTION
  * sample match IDs that previously returned 404 have been replaced
  * `pretty` has been deprecated
  * added region parameter example in "Getting a collection of matches"