### PR TITLE
Usage Tiers

### DIFF
--- a/docs/_usage_plans.md
+++ b/docs/_usage_plans.md
@@ -1,0 +1,22 @@
+# Rate Limits
+
+The API is free for non-commercial use with a default rate limit of 10 requests per minute.  If you need a higher limit, please contact api@superevilmegacorp.com and we'll hook you up!  
+
+# Usage Tiers
+
+We do our best to give out timely and accurate data so that we can work together to create awesome experiences for our players.  We classify projects into three categories.
+
+## Hobby Tier
+When you create a new API key, you're automatically placed into this tier.  This tier is intended to support non-commercial projects, SDKs, hackathons, and any projects that don't require a higher rate limit.
+
+The default rate limit is 10 requests per minute, and there is no access to data from the public beta environment.
+
+## Community Tier
+This tier is intended to be used by small commercial projects projects (those that derive revenue from ads, subscriptions, and more).  Access is still free, but we require that these projects share data with us about the way players use the project.  We use this to make sure we deliver the best possible experience for both your project and the players that use it.  This data is not shared with any other users of the API.  
+
+Rate limits in this tier are customized to the project, and we allow select community projects access to the public beta environment.
+
+## Commercial Tier
+This tier is intended to be used by large commercial projects projects (those that derive revenue from ads, subscriptions, and more).  Commercial project need high-volume low-cost access to data.  While the data provided is exactly the same as that provided to hobby and community tiers, commercial have additional options for accessing it.  In addition, there is no requirement to share data about how data is used.  
+
+Rate limits in this tier are customized to the project, and we allow select community projects access to the public beta environment.  Commercial users also get bulk access, increased webhook limits, statistical samples, and more.


### PR DESCRIPTION
This pull request adds (and hopefully clarifies) the API usage tiers that have been discussed many times in Discord, but never formalized.

Highlights:
  * There is, and will remain a free tier.  Woo!
  * We're permanently expanding the free tier, by adding a "community tier".  For an increased rate limit, you agree to share data about how you're using the data.  This isn't shared with any other API users, and we use it to see how players are using various sites and tools.  Initially this will only affect website by requiring that you include `gamelocker.js` on your site.  This will inject a google analytics tag.  
  * We're continuing to be a bit vague on the "commercial tier" but after chatting with several dozen large products, we have a clear idea of what they need.  These licenses are really focused at companies that have revenue or venture backing.  Because they are paid licenses, there will be no data sharing requirement.

UNRELATED: `gamelocker.js` will also add oembed support, allowing your site to convert telemetry files into visible graphs, etc.  